### PR TITLE
Fix typo in README (Pelco D Protocol)

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This is GPL software. Do with it as you want, but feed us back any improvements.
 
 This is a simple commmand line utility to control a PELCO PTZ camera via RS422/485
-'P' protocol. It supports all of the commands including UP, DOWN, IN, OUT, LEFT,
+'D' protocol. It supports all of the commands including UP, DOWN, IN, OUT, LEFT,
 RIGHT, NEAR, FAR, as well as the memory JUMP commands. 
 
 To use this, you need to put a RS232->RS422 adapter on the output


### PR DESCRIPTION
Spotted a small typo in the README. It mentioned Pelco P but should be Pelco D
